### PR TITLE
Chore: pin semver in GHA

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v4.2.2
 
       - name: setup go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version-file: "go.mod"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
           version: latest

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6
+        uses: goreleaser/goreleaser-action@v6.3.0
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+      - uses: actions/labeler@v5.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v4.2.2
 
       - name: setup go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version-file: "go.mod"
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest stable versions of their respective actions. These changes improve maintainability and ensure compatibility with the latest features and bug fixes.

### Workflow updates:

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L15-R23): Updated `actions/checkout` to `v4.2.2`, `actions/setup-go` to `v5.4.0`, and `golangci/golangci-lint-action` to `v7.0.0`.
* [`.github/workflows/goreleaser.yaml`](diffhunk://#diff-0c86f7c5d13980acfb64cbb524f1683e8610cd75bfa656074969488bbe1c2381L16-R27): Updated `actions/checkout` to `v4.2.2`, `actions/setup-go` to `v5.4.0`, and `goreleaser/goreleaser-action` to `v6.3.0`.
* [`.github/workflows/labeler.yaml`](diffhunk://#diff-5035e5e1050fac468f91ee7ad13264a79ef3e6e08a52af2110801aced423737dL12-R12): Updated `actions/labeler` to `v5.0.0`.
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L16-R19): Updated `actions/checkout` to `v4.2.2` and `actions/setup-go` to `v5.4.0`.