### PR TITLE
Chore: set permission

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: lint / golangci-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   go-mod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration files to enhance security by explicitly defining permissions for the workflows.

Security improvements in workflows:

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48R9-R11): Added `permissions` with `contents: read` to restrict access to repository contents during the execution of the `golangci-lint` workflow.
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R11-R13): Added `permissions` with `contents: read` to restrict access to repository contents during the execution of the `test` workflow.