### PR TITLE
Drop stale go: 1.23 pin from golangci-lint config (closes #75)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
 version: "2"
 run:
-  go: "1.23"
   allow-parallel-runners: true
 linters:
   default: none


### PR DESCRIPTION
## What

Remove the explicit `run.go: \"1.23\"` line from `.golangci.yaml` so golangci-lint reads the Go version from `go.mod` (currently `1.25.0`) automatically.

## Why

Linters like `staticcheck` and `govet` use this version to know which APIs and deprecations are in scope. Pinned to 1.23 while the module compiles against 1.25, the linter quietly applies older semantics and may miss new checks. Reading from `go.mod` is the standard recipe and keeps lint in sync with the module forever.

## Test plan

- [x] `golangci-lint run` still reports `0 issues` locally with the change applied

Closes #75