### PR TITLE
Correct Homebrew formula description (closes #77)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -109,7 +109,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: "https://github.com/oota-sushikuitee/nigiri"
-    description: "nigiri - A Git branch management tool"
+    description: "Manage upstream VCS repositories and build artifacts across versions"
     license: "MIT"
     commit_author:
       name: goreleaserbot


### PR DESCRIPTION
## What

Replace the goreleaser `brews[].description` from \"nigiri - A Git branch management tool\" to \"Manage upstream VCS repositories and build artifacts across versions\", which matches the actual purpose described in the README.

## Why

The previous description was inherited from an old project description and never updated. `brew info nigiri` and homebrew search currently surface the wrong summary. The next release will regenerate the formula in `Okabe-Junya/homebrew-tap` with the correct text.

Closes #77